### PR TITLE
CPU + GPU Ray projectors + range search on CPU

### DIFF
--- a/examples/binary_tree_example.py
+++ b/examples/binary_tree_example.py
@@ -1,0 +1,37 @@
+import paicos as pa
+import numpy as np
+from scipy.spatial import KDTree
+pa.use_units(False)
+from paicos.trees.bvh_cpu import BinaryTree
+snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
+                   load_catalog=False)
+center = np.array([398968.4, 211682.6, 629969.9])
+widths = np.array([2000, 2000, 2000])
+
+# Select a cube
+index = pa.util.get_index_of_cubic_region_plus_thin_layer(
+    snap['0_Coordinates'], center, widths,
+    snap['0_Diameters'], snap.box)
+
+snap = snap.select(index, parttype=0)
+
+pos = snap['0_Coordinates']
+sizes = snap['0_Diameters']
+
+# Construct a binary tree
+bvh_tree = BinaryTree(pos, 1.2 * sizes)
+
+bvh_dist, bvh_ids = bvh_tree.nearest_neighbor(pos)
+
+radius = 100.
+
+indices, num_neighbours = bvh_tree.range_search(pos, radius, max_neighbors=10)
+
+indices, num_neighbours = bvh_tree.range_search(pos, radius, max_neighbors=1000)
+
+brute_force_indices = []
+for ii in range(pos.shape[0]):
+    brute_force_indices.append(np.arange(pos.shape[0])[pa.util.get_index_of_radial_range(pos, pos[ii, :], 0, radius)])
+    np.testing.assert_array_equal(np.sort(indices[ii]), brute_force_indices[ii])
+
+

--- a/examples/binary_tree_example.py
+++ b/examples/binary_tree_example.py
@@ -1,8 +1,9 @@
 import paicos as pa
 import numpy as np
 from scipy.spatial import KDTree
-pa.use_units(False)
 from paicos.trees.bvh_cpu import BinaryTree
+
+pa.use_units(False)
 snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
                    load_catalog=False)
 center = np.array([398968.4, 211682.6, 629969.9])
@@ -33,5 +34,3 @@ brute_force_indices = []
 for ii in range(pos.shape[0]):
     brute_force_indices.append(np.arange(pos.shape[0])[pa.util.get_index_of_radial_range(pos, pos[ii, :], 0, radius)])
     np.testing.assert_array_equal(np.sort(indices[ii]), brute_force_indices[ii])
-
-

--- a/examples/example_binary_tree_non_volume_filling_points.py
+++ b/examples/example_binary_tree_non_volume_filling_points.py
@@ -1,0 +1,43 @@
+import paicos as pa
+import numpy as np
+from scipy.spatial import KDTree
+pa.use_units(False)
+from paicos.trees.bvh_cpu import BinaryTree
+snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
+                   load_catalog=False)
+center = np.array([398968.4, 211682.6, 629969.9])
+widths = np.array([2000, 2000, 2000])
+
+# Select a cube
+index = pa.util.get_index_of_cubic_region_plus_thin_layer(
+    snap['0_Coordinates'], center, widths,
+    snap['0_Diameters'], snap.box)
+
+snap = snap.select(index, parttype=0)
+
+pos = snap['0_Coordinates']
+sizes = snap['0_Diameters'] * 1e-1
+
+# Construct a binary tree
+bvh_tree = BinaryTree(pos, 1.2 * sizes)
+
+bvh_dist, bvh_ids = bvh_tree.nearest_neighbor(pos)
+
+# Construct a scipy kd tree
+kd_tree = KDTree(pos)
+
+kd_dist, kd_ids = kd_tree.query(pos)
+
+np.testing.assert_array_equal(kd_ids, bvh_ids)
+
+# Random query positions
+# Limit to well inside the tree, due to holes in cutout...
+pos2 = (0.1 + 0.8 * np.random.rand(10000, 3)) * widths[None, :]
+pos2 = (np.random.rand(10000, 3)) * widths[None, :]
+pos2 += (center - widths / 2)[None, :]
+
+bvh_dist2, bvh_ids2 = bvh_tree.nearest_neighbor(pos2)
+kd_dist2, kd_ids2 = kd_tree.query(pos2)
+
+np.testing.assert_array_equal(kd_ids2, bvh_ids2)
+pa.use_units(True)

--- a/examples/example_binary_tree_non_volume_filling_points.py
+++ b/examples/example_binary_tree_non_volume_filling_points.py
@@ -1,8 +1,9 @@
 import paicos as pa
 import numpy as np
 from scipy.spatial import KDTree
-pa.use_units(False)
 from paicos.trees.bvh_cpu import BinaryTree
+
+pa.use_units(False)
 snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
                    load_catalog=False)
 center = np.array([398968.4, 211682.6, 629969.9])

--- a/examples/example_cpu_ray_projector.py
+++ b/examples/example_cpu_ray_projector.py
@@ -1,9 +1,8 @@
-
 import paicos as pa
 import numpy as np
-pa.use_units(False)
-
 import matplotlib.pyplot as plt
+
+pa.use_units(False)
 
 snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
                    load_catalog=False)
@@ -25,7 +24,6 @@ for jj in range(3):
         snap['0_Coordinates'][ii][0] += jj * snap.box * 1 / 4
         snap['0_Coordinates'][ii][1] += kk * snap.box * 1 / 4
 
-
 plt.rc('image', origin='lower', cmap='RdBu_r', interpolation='None')
 plt.figure(1)
 plt.clf()
@@ -39,7 +37,6 @@ for ii, direction in enumerate(['z']):
     t = pa.RayProjector(snap, center, widths, direction, npix=512)
 
     density = t.project_variable('0_Density')
-
 
     p = pa.Projector(snap, center, widths, direction, npix=512)
 

--- a/examples/example_cpu_ray_projector.py
+++ b/examples/example_cpu_ray_projector.py
@@ -1,0 +1,60 @@
+
+import paicos as pa
+import numpy as np
+pa.use_units(False)
+
+import matplotlib.pyplot as plt
+
+snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
+                   load_catalog=False)
+
+snap['0_Coordinates'] = snap['0_Coordinates'][:9]
+snap['0_Volume'] = snap['0_Volume'][:9]
+snap['0_Masses'] = snap['0_Masses'][:9]
+snap['0_Density'] = snap['0_Density'][:9]
+
+for jj in range(3):
+    for kk in range(3):
+        ii = jj * 3 + kk
+        snap['0_Volume'][ii] = 4 * np.pi / 3 * (snap.box / 2 / (10 * (ii + 1)))**3
+        snap['0_Coordinates'][ii][0] = snap.box * 1 / 4
+        snap['0_Coordinates'][ii][1] = snap.box * 1 / 4
+        snap['0_Coordinates'][ii][2] = snap.box * 1 / 2
+        snap['0_Masses'][ii] = snap['0_Volume'][ii] * snap['0_Density'][ii]
+        # snap['0_Density'][ii] = 1.0
+        snap['0_Coordinates'][ii][0] += jj * snap.box * 1 / 4
+        snap['0_Coordinates'][ii][1] += kk * snap.box * 1 / 4
+
+
+plt.rc('image', origin='lower', cmap='RdBu_r', interpolation='None')
+plt.figure(1)
+plt.clf()
+fig, axes = plt.subplots(num=1, ncols=2,
+                         sharex='col', sharey='col')  # , sharey=True)
+
+widths = [snap.box, snap.box, snap.box]
+center = [snap.box / 2, snap.box / 2, snap.box / 2]
+for ii, direction in enumerate(['z']):
+
+    t = pa.RayProjector(snap, center, widths, direction, npix=512)
+
+    density = t.project_variable('0_Density')
+
+
+    p = pa.Projector(snap, center, widths, direction, npix=512)
+
+    Masses = p.project_variable('0_Masses')
+    Volume = p.project_variable('0_Volume')
+
+    normal_image = np.zeros_like(Masses)
+    normal_image[Masses > 0] = Masses[Masses > 0] / Volume[Masses > 0]
+
+    # Make a plot
+    axes[0].imshow(normal_image, origin='lower', extent=p.extent)
+    axes[1].imshow(density, origin='lower', extent=t.extent)
+    # print(np.max(np.abs(normal_image-nested_image)/normal_image))
+    # print(np.sum(normal_image.flatten()), np.sum(nested_image.flatten()))
+
+    axes[0].set_title('Sph projection')
+    axes[1].set_title('Ray projection')
+    plt.show()

--- a/examples/example_cpu_ray_projector_expensive.py
+++ b/examples/example_cpu_ray_projector_expensive.py
@@ -1,4 +1,3 @@
-
 import paicos as pa
 import numpy as np
 pa.use_units(False)
@@ -7,32 +6,12 @@ pa.numthreads(pa.settings.max_threads)
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 
-snap = pa.Snapshot(pa.data_dir, 247, basename='snap',
-                   load_catalog=True)
-
-# snap['0_Coordinates'] = snap['0_Coordinates'][:9]
-# snap['0_Volume'] = snap['0_Volume'][:9]
-# snap['0_Masses'] = snap['0_Masses'][:9]
-# snap['0_Density'] = snap['0_Density'][:9]
-
-# for jj in range(3):
-#     for kk in range(3):
-#         ii = jj * 3 + kk
-#         snap['0_Volume'][ii] = 4 * np.pi / 3 * (snap.box / 2 / (10 * (ii + 1)))**3
-#         snap['0_Coordinates'][ii][0] = snap.box * 1 / 4
-#         snap['0_Coordinates'][ii][1] = snap.box * 1 / 4
-#         snap['0_Coordinates'][ii][2] = snap.box * 1 / 2
-#         snap['0_Masses'][ii] = snap['0_Volume'][ii] * snap['0_Density'][ii]
-#         # snap['0_Density'][ii] = 1.0
-#         snap['0_Coordinates'][ii][0] += jj * snap.box * 1 / 4
-#         snap['0_Coordinates'][ii][1] += kk * snap.box * 1 / 4
-
+snap = pa.Snapshot(pa.data_dir, 247, basename='snap', load_catalog=True)
 
 plt.rc('image', origin='lower', cmap='RdBu_r', interpolation='None')
 plt.figure(1)
 plt.clf()
-fig, axes = plt.subplots(num=1, ncols=2,
-                         sharex='col', sharey='col')  # , sharey=True)
+fig, axes = plt.subplots(num=1, ncols=3, sharex='col', sharey='col')
 
 widths = [snap.box/2, snap.box/2, snap.box/2]
 center = [snap.box / 2, snap.box / 2, snap.box / 2]
@@ -40,23 +19,20 @@ center = [snap.box / 2, snap.box / 2, snap.box / 2]
 widths = [20000, 20000, 20000]
 center = snap.Cat.Group['GroupPos'][0]
 
-for ii, direction in enumerate(['z']):
+r = pa.RayProjector(snap, center, widths, 'z', npix=128, tol=0.05, verbose=False, timing=True, do_pre_selection=True)
 
-    r = pa.RayProjector(snap, center, widths, direction, npix=512, tol=0.25, verbose=False, timing=True, do_pre_selection=True)
+density = r.project_variable('0_Density', additive=False, timing=True)
 
-    density = r.project_variable('0_Density', additive=False, timing=True)
+t = pa.TreeProjector(snap, center, widths, 'z', npix=128, tol=0.05, verbose=False, timing=True)
 
+t_density = t.project_variable('0_Density', additive=False, timing=True)
 
-    t = pa.TreeProjector(snap, center, widths, direction, npix=512, tol=1, verbose=False, timing=True)
+# Make a plot
+axes[0].imshow(t_density, origin='lower', extent=t.extent, norm=LogNorm())
+axes[1].imshow(density, origin='lower', extent=r.extent, norm=LogNorm())
+axes[2].imshow((density - t_density) / density, origin='lower', extent=r.extent)
 
-    t_density = t.project_variable('0_Density', additive=False, timing=True)
-
-    # Make a plot
-    axes[0].imshow(t_density, origin='lower', extent=t.extent, norm=LogNorm())
-    axes[1].imshow(density, origin='lower', extent=r.extent, norm=LogNorm())
-    # print(np.max(np.abs(normal_image-nested_image)/normal_image))
-    # print(np.sum(normal_image.flatten()), np.sum(nested_image.flatten()))
-
-    axes[0].set_title('TreeProjector')
-    axes[1].set_title('RayProjector')
-    plt.show()
+axes[0].set_title('TreeProjector')
+axes[1].set_title('RayProjector')
+axes[2].set_title('Rel. difference')
+plt.show()

--- a/examples/example_cpu_ray_projector_expensive.py
+++ b/examples/example_cpu_ray_projector_expensive.py
@@ -1,10 +1,10 @@
 import paicos as pa
 import numpy as np
-pa.use_units(False)
-
-pa.numthreads(pa.settings.max_threads)
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
+
+pa.use_units(False)
+pa.numthreads(pa.settings.max_threads)
 
 snap = pa.Snapshot(pa.data_dir, 247, basename='snap', load_catalog=True)
 
@@ -13,7 +13,7 @@ plt.figure(1)
 plt.clf()
 fig, axes = plt.subplots(num=1, ncols=3, sharex='col', sharey='col')
 
-widths = [snap.box/2, snap.box/2, snap.box/2]
+widths = [snap.box / 2, snap.box / 2, snap.box / 2]
 center = [snap.box / 2, snap.box / 2, snap.box / 2]
 
 widths = [20000, 20000, 20000]

--- a/examples/example_cpu_ray_projector_expensive.py
+++ b/examples/example_cpu_ray_projector_expensive.py
@@ -1,0 +1,62 @@
+
+import paicos as pa
+import numpy as np
+pa.use_units(False)
+
+pa.numthreads(pa.settings.max_threads)
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+
+snap = pa.Snapshot(pa.data_dir, 247, basename='snap',
+                   load_catalog=True)
+
+# snap['0_Coordinates'] = snap['0_Coordinates'][:9]
+# snap['0_Volume'] = snap['0_Volume'][:9]
+# snap['0_Masses'] = snap['0_Masses'][:9]
+# snap['0_Density'] = snap['0_Density'][:9]
+
+# for jj in range(3):
+#     for kk in range(3):
+#         ii = jj * 3 + kk
+#         snap['0_Volume'][ii] = 4 * np.pi / 3 * (snap.box / 2 / (10 * (ii + 1)))**3
+#         snap['0_Coordinates'][ii][0] = snap.box * 1 / 4
+#         snap['0_Coordinates'][ii][1] = snap.box * 1 / 4
+#         snap['0_Coordinates'][ii][2] = snap.box * 1 / 2
+#         snap['0_Masses'][ii] = snap['0_Volume'][ii] * snap['0_Density'][ii]
+#         # snap['0_Density'][ii] = 1.0
+#         snap['0_Coordinates'][ii][0] += jj * snap.box * 1 / 4
+#         snap['0_Coordinates'][ii][1] += kk * snap.box * 1 / 4
+
+
+plt.rc('image', origin='lower', cmap='RdBu_r', interpolation='None')
+plt.figure(1)
+plt.clf()
+fig, axes = plt.subplots(num=1, ncols=2,
+                         sharex='col', sharey='col')  # , sharey=True)
+
+widths = [snap.box/2, snap.box/2, snap.box/2]
+center = [snap.box / 2, snap.box / 2, snap.box / 2]
+
+widths = [20000, 20000, 20000]
+center = snap.Cat.Group['GroupPos'][0]
+
+for ii, direction in enumerate(['z']):
+
+    r = pa.RayProjector(snap, center, widths, direction, npix=512, tol=0.25, verbose=False, timing=True, do_pre_selection=True)
+
+    density = r.project_variable('0_Density', additive=False, timing=True)
+
+
+    t = pa.TreeProjector(snap, center, widths, direction, npix=512, tol=1, verbose=False, timing=True)
+
+    t_density = t.project_variable('0_Density', additive=False, timing=True)
+
+    # Make a plot
+    axes[0].imshow(t_density, origin='lower', extent=t.extent, norm=LogNorm())
+    axes[1].imshow(density, origin='lower', extent=r.extent, norm=LogNorm())
+    # print(np.max(np.abs(normal_image-nested_image)/normal_image))
+    # print(np.sum(normal_image.flatten()), np.sum(nested_image.flatten()))
+
+    axes[0].set_title('TreeProjector')
+    axes[1].set_title('RayProjector')
+    plt.show()

--- a/examples/ray_projector_example.py
+++ b/examples/ray_projector_example.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from matplotlib.colors import LogNorm
 import paicos as pa
 import numpy as np
@@ -13,7 +14,9 @@ widths = [10000, 10000, 2 * R200c]
 projector = pa.RayProjector(snap, center, widths, 'z', npix=512, tol=1, timing=True)
 extent = projector.centered_extent.to_physical.to('Mpc')
 
-images = projector.project_variables(["0_Masses", "0_Volume", "0_Density", "0_Temperatures", "0_MagneticFieldSquaredTimesVolume"], [True, True, False, False, True], timing=True)
+variables = ["0_Masses", "0_Volume", "0_Density", "0_Temperatures", "0_MagneticFieldSquaredTimesVolume"]
+additive = [True, True, False, False, True]
+images = projector.project_variables(variables, additive, timing=True)
 Masses = images[0]
 Volume = images[1]
 Density = images[2]
@@ -21,9 +24,6 @@ T = images[3].to('keV')
 B = (np.sqrt(images[4] / images[1])).to_physical.to('uG')
 
 # Make plots
-import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 # --- Figure 1 ---
 plt.figure(1)

--- a/examples/ray_projector_example.py
+++ b/examples/ray_projector_example.py
@@ -1,0 +1,69 @@
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+import paicos as pa
+import numpy as np
+
+pa.use_units(True)
+
+snap = pa.Snapshot(pa.data_dir, 247)
+center = snap.Cat.Group['GroupPos'][0]
+R200c = snap.Cat.Group['Group_R_Crit200'][0].value
+widths = [10000, 10000, 2 * R200c]
+
+projector = pa.RayProjector(snap, center, widths, 'z', npix=512, tol=1, timing=True)
+extent = projector.centered_extent.to_physical.to('Mpc')
+
+images = projector.project_variables(["0_Masses", "0_Volume", "0_Density", "0_Temperatures", "0_MagneticFieldSquaredTimesVolume"], [True, True, False, False, True], timing=True)
+Masses = images[0]
+Volume = images[1]
+Density = images[2]
+T = images[3].to('keV')
+B = (np.sqrt(images[4] / images[1])).to_physical.to('uG')
+
+# Make plots
+import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+# --- Figure 1 ---
+plt.figure(1)
+plt.clf()
+fig, axes = plt.subplots(num=1, ncols=2, sharey=True)
+im0 = axes[0].imshow(np.array((Masses / Volume)), origin='lower', extent=extent.value, norm=LogNorm())
+im1 = axes[1].imshow(np.array(Density), origin='lower', extent=extent.value, norm=LogNorm())
+
+for ax in axes:
+    ax.set_xlabel(extent.label('x'))
+axes[0].set_ylabel(extent.label('y'))
+
+# Colorbars above images
+for ax, im, label in zip(axes, [im0, im1], [(Masses / Volume).label(r'M / V'), Density.label(r'\rho')]):
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("top", size="5%", pad=0.15)
+    cbar = plt.colorbar(im, cax=cax, orientation='horizontal')
+    cbar.set_label(label)
+    cax.xaxis.set_ticks_position('top')
+    cax.xaxis.set_label_position('top')
+
+
+# --- Figure 2 ---
+plt.figure(2)
+plt.clf()
+fig, axes = plt.subplots(num=2, ncols=2, sharey=True)
+im0 = axes[0].imshow(np.array((B)), origin='lower', extent=extent.value, norm=LogNorm())
+im1 = axes[1].imshow(np.array(T), origin='lower', extent=extent.value, norm=LogNorm())
+
+for ax in axes:
+    ax.set_xlabel(extent.label('x'))
+axes[0].set_ylabel(extent.label('y'))
+
+# Colorbars above images
+for ax, im, label in zip(axes, [im0, im1], [B.label(r'B'), T.label(r'T')]):
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("top", size="5%", pad=0.15)
+    cbar = plt.colorbar(im, cax=cax, orientation='horizontal')
+    cbar.set_label(label)
+    cax.xaxis.set_ticks_position('top')
+    cax.xaxis.set_label_position('top')
+
+plt.show()

--- a/paicos/__init__.py
+++ b/paicos/__init__.py
@@ -183,7 +183,6 @@ def add_user_unit(field, blockname, unit):
 
     util.user_unit_dict[field][blockname] = unit
 
-
 def numthreads(numthreads):
     """
     Pass the number of threads you would like to use for parallel execution.
@@ -203,7 +202,10 @@ def numthreads(numthreads):
 
     try:
         from numba import set_num_threads
-        set_num_threads(settings.numthreads)
+        from .misc import suppress_omp_nested_warning
+
+        with suppress_omp_nested_warning():
+            set_num_threads(settings.numthreads)
     except:
         pass
         # print("numba not installed")

--- a/paicos/__init__.py
+++ b/paicos/__init__.py
@@ -43,6 +43,7 @@ from .image_creators.image_creator import ImageCreator
 from .image_creators.projector import Projector
 from .image_creators.nested_projector import NestedProjector
 from .image_creators.tree_projector import TreeProjector
+from .image_creators.ray_projector import RayProjector
 from .image_creators.slicer import Slicer
 from .image_creators.image_creator_actions import Actions
 

--- a/paicos/__init__.py
+++ b/paicos/__init__.py
@@ -183,6 +183,7 @@ def add_user_unit(field, blockname, unit):
 
     util.user_unit_dict[field][blockname] = unit
 
+
 def numthreads(numthreads):
     """
     Pass the number of threads you would like to use for parallel execution.
@@ -206,9 +207,10 @@ def numthreads(numthreads):
 
         with suppress_omp_nested_warning():
             set_num_threads(settings.numthreads)
-    except:
-        pass
-        # print("numba not installed")
+    except Exception as e:
+        print(e)
+        import warnings
+        warnings.warn("Something went wrong. Perhaps numba is not installed?")
 
 
 def print_info_when_deriving_variables(option):

--- a/paicos/__init__.py
+++ b/paicos/__init__.py
@@ -201,6 +201,13 @@ def numthreads(numthreads):
     else:
         settings.numthreads_reduction = settings.numthreads
 
+    try:
+        from numba import set_num_threads
+        set_num_threads(settings.numthreads)
+    except:
+        pass
+        # print("numba not installed")
+
 
 def print_info_when_deriving_variables(option):
     """

--- a/paicos/cython/get_index_of_region.pyx
+++ b/paicos/cython/get_index_of_region.pyx
@@ -315,7 +315,7 @@ def get_radial_range(real_t [:, :] pos, real_t xc, real_t yc,
 
         # Index calculation
         index[ip] = 0
-        if (r2 < r2_max) and (r2 > r2_min):
+        if (r2 < r2_max) and (r2 >= r2_min):
             index[ip] = 1
 
     # Return a numpy boolean array
@@ -371,10 +371,10 @@ def get_radial_range_plus_thin_layer(real_t [:, :] pos, real_t xc, real_t yc,
         if (r_min > thickness[ip]):
             r2_min = (r_min - thickness[ip])*(r_min - thickness[ip])
         r2_max = (r_max + thickness[ip])*(r_max + thickness[ip])
-        
+
         # Index calculation
         index[ip] = 0
-        if (r2 < r2_max) and (r2 > r2_min):
+        if (r2 < r2_max) and (r2 >= r2_min):
             index[ip] = 1
 
     # Return a numpy boolean array

--- a/paicos/cython/ray_tracer.pyx
+++ b/paicos/cython/ray_tracer.pyx
@@ -1,0 +1,188 @@
+from cython.parallel import prange, parallel
+from libc.math cimport fmin, fmax, sqrt
+from libc.stdlib cimport malloc, free
+cimport openmp
+import numpy as np
+cimport numpy as np
+
+ctypedef double real_t
+
+cdef inline int rotate_point_around_center(real_t[:] point,
+                                            real_t[:] tmp_point,
+                                            real_t[:] center,
+                                            real_t[:, :] rotation_matrix) noexcept nogil:
+    cdef int ii, jj
+
+    # Subtract center and zero out point
+    for ii in range(3):
+        tmp_point[ii] = point[ii] - center[ii]
+        point[ii] = 0.0
+
+    # Matrix-vector multiplication
+    for ii in range(3):
+        for jj in range(3):
+            point[ii] += rotation_matrix[ii, jj] * tmp_point[jj]
+
+    # Add center back
+    for ii in range(3):
+        point[ii] += center[ii]
+
+    return 0
+
+
+cdef inline real_t distance(real_t[:] p1, real_t[:] p2) noexcept nogil:
+    cdef real_t dx = p1[0] - p2[0]
+    cdef real_t dy = p1[1] - p2[1]
+    cdef real_t dz = p1[2] - p2[2]
+    return dx*dx + dy*dy + dz*dz
+
+cdef inline real_t distance_to_box(real_t[:] p, unsigned long[:, :] bounds) noexcept nogil:
+    cdef real_t dx = 0.0, dy = 0.0, dz = 0.0
+    cdef real_t q
+    for i in range(3):
+        if p[i] < bounds[i, 0]:
+            q = bounds[i, 0] - p[i]
+            if i == 0: dx = q
+            elif i == 1: dy = q
+            else: dz = q
+        elif p[i] > bounds[i, 1]:
+            q = p[i] - bounds[i, 1]
+            if i == 0: dx = q
+            elif i == 1: dy = q
+            else: dz = q
+    return dx*dx + dy*dy + dz*dz
+
+cdef inline int nearest_neighbor(real_t[:, :] points, long[:] tree_parents,
+                                   long[:, :] tree_children, unsigned long[:, :, :] tree_bounds,
+                                   real_t[:] query_point, int num_internal_nodes) noexcept nogil:
+    cdef int queue[128]
+    cdef int queue_index = 0
+    queue[queue_index] = 0
+    cdef int L = 21
+    cdef real_t min_dist = (2 ** L - 1.0)
+    cdef int min_index = -1
+    cdef int node_id, childA, childB, data_id
+    cdef bint is_leafA, is_leafB
+    cdef real_t dist, distA, distB
+    cdef bint traverseA, traverseB
+
+    while queue_index >= 0:
+        node_id = queue[queue_index]
+        childA = tree_children[node_id, 0]
+        childB = tree_children[node_id, 1]
+
+        is_leafA = childA >= num_internal_nodes
+        is_leafB = childB >= num_internal_nodes
+
+        if is_leafA:
+            data_id = childA - num_internal_nodes
+            dist = distance(points[data_id], query_point)
+            if dist < min_dist:
+                min_dist = dist
+                min_index = data_id
+
+        if is_leafB:
+            data_id = childB - num_internal_nodes
+            dist = distance(points[data_id], query_point)
+            if dist < min_dist:
+                min_dist = dist
+                min_index = data_id
+
+        distA = distance_to_box(query_point, tree_bounds[childA])
+        distB = distance_to_box(query_point, tree_bounds[childB])
+
+        traverseA = (distA <= min_dist) and not is_leafA
+        traverseB = (distB <= min_dist) and not is_leafB
+
+        if not traverseA and not traverseB:
+            queue_index -= 1
+        else:
+            if traverseA:
+                queue[queue_index] = childA
+            else:
+                queue[queue_index] = childB
+            if traverseA and traverseB:
+                queue_index += 1
+                queue[queue_index] = childB
+
+    return min_index
+
+
+# from cython.parallel cimport prange, parallel
+# from libc.math cimport fmin, fmax
+
+# # Assume real_t is already defined, e.g.
+# # ctypedef double real_t
+
+# from cython.parallel cimport prange, parallel
+# from libc.math cimport sqrt
+# cimport cython
+
+# # Assume: real_t is already defined (e.g., ctypedef double real_t)
+# # Also assume: nearest_neighbor() and rotate_point_around_center() are declared elsewhere and cimported
+
+def trace_rays_cpu(real_t[:, :] points,
+                   long[:] tree_parents,
+                   long[:, :] tree_children,
+                   unsigned long[:, :, :] tree_bounds,
+                   real_t[:] variable,
+                   real_t[:] hsml,
+                   real_t[:] widths,
+                   real_t[:] center,
+                   real_t tree_scale_factor,
+                   real_t[:] tree_offsets,
+                   real_t[:, :] image,
+                   real_t[:, :] rotation_matrix,
+                   real_t tol,
+                   int numthreads):
+
+    cdef int nx = image.shape[0]
+    cdef int ny = image.shape[1]
+    cdef real_t dx = widths[0] / nx
+    cdef real_t dy = widths[1] / ny
+
+    cdef int ix, iy, i
+    cdef real_t z, dz, result
+    cdef real_t min_dist
+    cdef int min_index
+
+    cdef int num_internal_nodes = tree_children.shape[0]
+
+    cdef real_t query_point[3]
+    cdef real_t tmp_point[3]
+
+    # with nogil, parallel(num_threads=numthreads):
+    # for ix in range(nx, schedule='static'):
+    for ix in range(nx):
+        for iy in range(ny):
+            result = 0.0
+            z = 0.0
+
+            while z < widths[2]:
+                # Compute query point in world coordinates
+                query_point[0] = (center[0] - widths[0] / 2.0) + (ix + 0.5) * dx
+                query_point[1] = (center[1] - widths[1] / 2.0) + (iy + 0.5) * dy
+                query_point[2] = (center[2] - widths[2] / 2.0) + z
+
+                # Rotate point around center (in-place)
+                rotate_point_around_center(query_point, tmp_point, center, rotation_matrix)
+
+                # Transform to tree coordinates
+                for i in range(3):
+                    query_point[i] = (query_point[i] - tree_offsets[i]) * tree_scale_factor
+
+                # Nearest neighbor
+                min_index = nearest_neighbor(points, tree_parents, tree_children,
+                                            tree_bounds, query_point, num_internal_nodes)
+
+                min_dist = distance(points[min_index], query_point)
+                min_dist = sqrt(min_dist)
+
+                # Adaptive integration step (convert to Arepo units)
+                dz = tol * min_dist / tree_scale_factor
+                result = result + dz * variable[min_index]
+                z = z + dz
+
+            # Overshoot correction
+            result -= (z - widths[2]) * variable[min_index]
+            image[ix, iy] = result

--- a/paicos/cython/ray_tracer.pyx
+++ b/paicos/cython/ray_tracer.pyx
@@ -34,27 +34,24 @@ cdef inline real_t distance(real_t[:] p1, real_t[:] p2) noexcept nogil:
     cdef real_t dx = p1[0] - p2[0]
     cdef real_t dy = p1[1] - p2[1]
     cdef real_t dz = p1[2] - p2[2]
-    return dx*dx + dy*dy + dz*dz
+    return sqrt(dx*dx + dy*dy + dz*dz)
 
-cdef inline real_t distance_to_box(real_t[:] p, unsigned long[:, :] bounds) noexcept nogil:
-    cdef real_t dx = 0.0, dy = 0.0, dz = 0.0
-    cdef real_t q
+cdef inline real_t distance_to_box(real_t[:] point, unsigned long[:, :] box) noexcept nogil:
+    cdef real_t d
+    cdef real_t sq_dist = 0.0
+    cdef int i
     for i in range(3):
-        if p[i] < bounds[i, 0]:
-            q = bounds[i, 0] - p[i]
-            if i == 0: dx = q
-            elif i == 1: dy = q
-            else: dz = q
-        elif p[i] > bounds[i, 1]:
-            q = p[i] - bounds[i, 1]
-            if i == 0: dx = q
-            elif i == 1: dy = q
-            else: dz = q
-    return dx*dx + dy*dy + dz*dz
+        if point[i] < box[i, 0]:
+            d = box[i, 0] - point[i]
+            sq_dist += d * d
+        elif point[i] > box[i, 1]:
+            d = point[i] - box[i, 1]
+            sq_dist += d * d
+    return sqrt(sq_dist)
 
 cdef inline int nearest_neighbor(real_t[:, :] points, long[:] tree_parents,
                                    long[:, :] tree_children, unsigned long[:, :, :] tree_bounds,
-                                   real_t[:] query_point, int num_internal_nodes) noexcept nogil:
+                                   real_t[:] query_point, int num_internal_nodes, real_t[:] min_dist_final) noexcept nogil:
     cdef int queue[128]
     cdef int queue_index = 0
     queue[queue_index] = 0
@@ -104,9 +101,71 @@ cdef inline int nearest_neighbor(real_t[:, :] points, long[:] tree_parents,
             if traverseA and traverseB:
                 queue_index += 1
                 queue[queue_index] = childB
-
+    min_dist_final[0] = min_dist
     return min_index
 
+cdef inline bint is_point_in_box(real_t[:] point, unsigned long[:, :] box) noexcept nogil:
+    cdef int ii
+    for ii in range(3):
+        if point[ii] < box[ii, 0] or point[ii] > box[ii, 1]:
+            return False
+    return True
+
+cdef inline int nearest_neighbor_voronoi(real_t[:, :] points, long[:] tree_parents,
+                                   long[:, :] tree_children, unsigned long[:, :, :] tree_bounds,
+                                   real_t[:] query_point, int num_internal_nodes, real_t[:] min_dist_final) noexcept nogil:
+    cdef int queue[128]
+    cdef int queue_index = 0
+    queue[queue_index] = 0
+    cdef int L = 21
+    cdef real_t min_dist = (2 ** L - 1.0)
+    cdef int min_index = -1
+    cdef int node_id, childA, childB, data_id
+    cdef bint is_leafA, is_leafB, point_in_A, point_in_B
+    cdef real_t dist, distA, distB
+    cdef bint traverseA, traverseB
+
+    while queue_index >= 0:
+        node_id = queue[queue_index]
+        childA = tree_children[node_id, 0]
+        childB = tree_children[node_id, 1]
+
+        is_leafA = childA >= num_internal_nodes
+        is_leafB = childB >= num_internal_nodes
+
+        point_in_A = is_point_in_box(query_point, tree_bounds[childA])
+        point_in_B = is_point_in_box(query_point, tree_bounds[childB])
+
+        if point_in_A and is_leafA:
+            data_id = childA - num_internal_nodes
+            dist = distance(points[data_id], query_point)
+            if dist < min_dist:
+                min_dist = dist
+                min_index = data_id
+
+        if point_in_B and is_leafB:
+            data_id = childB - num_internal_nodes
+            dist = distance(points[data_id], query_point)
+            if dist < min_dist:
+                min_dist = dist
+                min_index = data_id
+
+        # Whether to traverse
+        traverseA = point_in_A and not is_leafA
+        traverseB = point_in_B and not is_leafB
+
+        if not traverseA and not traverseB:
+            queue_index -= 1
+        else:
+            if traverseA:
+                queue[queue_index] = childA
+            else:
+                queue[queue_index] = childB
+            if traverseA and traverseB:
+                queue_index += 1
+                queue[queue_index] = childB
+    min_dist_final[0] = min_dist
+    return min_index
 
 # from cython.parallel cimport prange, parallel
 # from libc.math cimport fmin, fmax
@@ -148,8 +207,9 @@ def trace_rays_cpu(real_t[:, :] points,
 
     cdef int num_internal_nodes = tree_children.shape[0]
 
-    cdef real_t query_point[3]
-    cdef real_t tmp_point[3]
+    cdef real_t[:] query_point = np.zeros((3), dtype=np.float64)
+    cdef real_t[:] tmp_point = np.zeros((3), dtype=np.float64)
+    cdef real_t[:] min_dist_final = np.zeros((1), dtype=np.float64)
 
     # with nogil, parallel(num_threads=numthreads):
     # for ix in range(nx, schedule='static'):
@@ -173,13 +233,85 @@ def trace_rays_cpu(real_t[:, :] points,
 
                 # Nearest neighbor
                 min_index = nearest_neighbor(points, tree_parents, tree_children,
-                                            tree_bounds, query_point, num_internal_nodes)
+                                            tree_bounds, query_point, num_internal_nodes, min_dist_final)
 
-                min_dist = distance(points[min_index], query_point)
-                min_dist = sqrt(min_dist)
+                # min_dist = distance(points[min_index], query_point)
+                min_dist = min_dist_final[0]
 
                 # Adaptive integration step (convert to Arepo units)
                 dz = tol * min_dist / tree_scale_factor
+                result = result + dz * variable[min_index]
+                z = z + dz
+
+            # Overshoot correction
+            result -= (z - widths[2]) * variable[min_index]
+            image[ix, iy] = result
+
+
+def trace_rays_cpu_voronoi(real_t[:, :] points,
+                   long[:] tree_parents,
+                   long[:, :] tree_children,
+                   unsigned long[:, :, :] tree_bounds,
+                   real_t[:] variable,
+                   real_t[:] hsml,
+                   real_t[:] widths,
+                   real_t[:] center,
+                   real_t tree_scale_factor,
+                   real_t[:] tree_offsets,
+                   real_t[:, :] image,
+                   real_t[:, :] rotation_matrix,
+                   real_t tol,
+                   int numthreads):
+
+    cdef int nx = image.shape[0]
+    cdef int ny = image.shape[1]
+    cdef real_t dx = widths[0] / nx
+    cdef real_t dy = widths[1] / ny
+
+    cdef int ix, iy, i
+    cdef real_t z, dz, result
+    cdef real_t min_dist
+    cdef int min_index
+
+    cdef int num_internal_nodes = tree_children.shape[0]
+
+    cdef real_t[:] query_point = np.zeros((3), dtype=np.float64)
+    cdef real_t[:] tmp_point = np.zeros((3), dtype=np.float64)
+    cdef real_t[:] min_dist_final = np.zeros((1), dtype=np.float64)
+
+    # with nogil, parallel(num_threads=numthreads):
+    # for ix in range(nx, schedule='static'):
+    for ix in range(nx):
+        for iy in range(ny):
+            result = 0.0
+            z = 0.0
+
+            while z < widths[2]:
+                # Compute query point in world coordinates
+                query_point[0] = (center[0] - widths[0] / 2.0) + (ix + 0.5) * dx
+                query_point[1] = (center[1] - widths[1] / 2.0) + (iy + 0.5) * dy
+                query_point[2] = (center[2] - widths[2] / 2.0) + z
+
+                # Rotate point around center (in-place)
+                rotate_point_around_center(query_point, tmp_point, center, rotation_matrix)
+
+                # Transform to tree coordinates
+                for i in range(3):
+                    query_point[i] = (query_point[i] - tree_offsets[i]) * tree_scale_factor
+
+                # Nearest neighbor
+                min_index = nearest_neighbor_voronoi(points, tree_parents, tree_children,
+                                            tree_bounds, query_point, num_internal_nodes, min_dist_final)
+                if min_index == -1:
+                    min_index = nearest_neighbor(points, tree_parents, tree_children,
+                                            tree_bounds, query_point, num_internal_nodes, min_dist_final)
+
+
+                # min_dist = distance(points[min_index], query_point)
+                min_dist = min_dist_final[0]
+
+                # Adaptive integration step (convert to Arepo units)
+                dz = tol * hsml[min_index]
                 result = result + dz * variable[min_index]
                 z = z + dz
 

--- a/paicos/image_creators/gpu_ray_projector.py
+++ b/paicos/image_creators/gpu_ray_projector.py
@@ -141,14 +141,14 @@ class GpuRayProjector(ImageCreator):
 
         """
 
-        err_msg = ('GpuRayProjector currently only works for parttype 0.' +
-                    ' This is because the GPU version  of BVH tree' +
-                    ' assumes that the query points are inside the bounding' +
-                    ' boxes of the leaves of the tree. This has been fixed for' +
-                    ' the CPU version. Please send Thomas an email if you see' +
-                    ' this error message.')
+        # err_msg = ('GpuRayProjector currently only works for parttype 0.' +
+        #             ' This is because the GPU version  of BVH tree' +
+        #             ' assumes that the query points are inside the bounding' +
+        #             ' boxes of the leaves of the tree. This has been fixed for' +
+        #             ' the CPU version. Please send Thomas an email if you see' +
+        #             ' this error message.')
 
-        assert parttype == 0, err_msg
+        # assert parttype == 0, err_msg
 
         # call the superclass constructor to initialize the ImageCreator class
         super().__init__(snap, center, widths, direction, npix=npix, parttype=parttype)

--- a/paicos/image_creators/gpu_ray_projector.py
+++ b/paicos/image_creators/gpu_ray_projector.py
@@ -101,7 +101,7 @@ def trace_rays(points, tree_parents, tree_children, tree_bounds, variable, hsml,
 
 
 @cuda.jit
-def trace_rays_cpu_optimized(points, tree_parents, tree_children, tree_bounds, variable, hsml,
+def trace_rays_optimized(points, tree_parents, tree_children, tree_bounds, variable, hsml,
                widths, center,
                tree_scale_factor, tree_offsets, image, rotation_matrix, tol):
 
@@ -361,7 +361,7 @@ class GpuRayProjector(ImageCreator):
         blocks_y = get_blocks(ny, self.threadsperblock)
         btuple = (blocks_x, blocks_y)
         ttuple = (self.threadsperblock, self.threadsperblock)
-        trace_rays[btuple, ttuple](self.tree._pos, self.tree.parents, self.tree.children,
+        trace_rays_optimized[btuple, ttuple](self.tree._pos, self.tree.parents, self.tree.children,
                                    self.tree.bounds, variable, hsml, widths, center,
                                    tree_scale_factor, tree_offsets, image,
                                    rotation_matrix, self.tol)

--- a/paicos/image_creators/gpu_ray_projector.py
+++ b/paicos/image_creators/gpu_ray_projector.py
@@ -47,6 +47,8 @@ def trace_rays_voronoi(points, tree_parents, tree_children, tree_bounds, variabl
     nx = image.shape[0]
     ny = image.shape[1]
 
+    L = 21
+
     if ix >= 0 and ix < nx and iy >= 0 and iy < ny:
         result = 0.0
 

--- a/paicos/image_creators/gpu_ray_projector.py
+++ b/paicos/image_creators/gpu_ray_projector.py
@@ -85,7 +85,8 @@ def trace_rays(points, tree_parents, tree_children, tree_bounds, variable, hsml,
                                                           num_internal_nodes)
 
             # Calculate dz
-            dz = tol * hsml[min_index]
+            # dz = tol * hsml[min_index]
+            dz = tol * min_dist / tree_scale_factor
 
             # Update integral
             result = result + dz * variable[min_index]

--- a/paicos/image_creators/gpu_ray_projector.py
+++ b/paicos/image_creators/gpu_ray_projector.py
@@ -39,8 +39,8 @@ def rotate_point_around_center(point, tmp_point, center, rotation_matrix):
 
 @cuda.jit
 def trace_rays_voronoi(points, tree_parents, tree_children, tree_bounds, variable, hsml,
-               widths, center,
-               tree_scale_factor, tree_offsets, image, rotation_matrix, tol):
+                       widths, center,
+                       tree_scale_factor, tree_offsets, image, rotation_matrix, tol):
 
     ix, iy = cuda.grid(2)
 
@@ -88,8 +88,8 @@ def trace_rays_voronoi(points, tree_parents, tree_children, tree_bounds, variabl
 
             if min_index == -1:
                 min_dist, min_index = nearest_neighbor_device_optimized(points, tree_parents, tree_children,
-                                              tree_bounds, query_point,
-                                              num_internal_nodes, 2**L - 1.0)
+                                                                        tree_bounds, query_point,
+                                                                        num_internal_nodes, 2**L - 1.0)
 
             # Calculate dz
             # dz = tol * hsml[min_index]
@@ -109,8 +109,8 @@ def trace_rays_voronoi(points, tree_parents, tree_children, tree_bounds, variabl
 
 @cuda.jit
 def trace_rays_optimized(points, tree_parents, tree_children, tree_bounds, variable, hsml,
-               widths, center,
-               tree_scale_factor, tree_offsets, image, rotation_matrix, tol):
+                         widths, center,
+                         tree_scale_factor, tree_offsets, image, rotation_matrix, tol):
 
     ix, iy = cuda.grid(2)
 
@@ -155,8 +155,8 @@ def trace_rays_optimized(points, tree_parents, tree_children, tree_bounds, varia
                               ) * tree_scale_factor
 
             min_dist, min_index = nearest_neighbor_device_optimized(points, tree_parents, tree_children,
-                                                          tree_bounds, query_point,
-                                                          num_internal_nodes, max_search_dist)
+                                                                    tree_bounds, query_point,
+                                                                    num_internal_nodes, max_search_dist)
 
             # Calculate dz
             # dz = tol * hsml[min_index]

--- a/paicos/image_creators/gpu_ray_projector.py
+++ b/paicos/image_creators/gpu_ray_projector.py
@@ -109,9 +109,10 @@ class GpuRayProjector(ImageCreator):
     It only works on cuda-enabled GPUs.
     """
 
+    @util.conditional_timer
     def __init__(self, snap, center, widths, direction,
                  npix=512, parttype=0, tol=0.25, threadsperblock=8,
-                 do_pre_selection=False):
+                 do_pre_selection=False, timing=False):
         """
         Initialize the Projector class.
 
@@ -338,7 +339,8 @@ class GpuRayProjector(ImageCreator):
 
         return variable_str, unit_quantity
 
-    def project_variable(self, variable, additive=False):
+    @util.conditional_timer
+    def project_variable(self, variable, additive=False, timing=False):
         """
         projects a given variable onto a 2D plane.
 

--- a/paicos/image_creators/ray_projector.py
+++ b/paicos/image_creators/ray_projector.py
@@ -151,8 +151,7 @@ def trace_rays_cpu_optimized(points, tree_parents, tree_children, tree_bounds, v
                 # Adaptive step in Arepo units
                 # dz = tol * hsml[min_index]
                 dz = 2.0 * tol * min_dist / tree_scale_factor
-                # dz = 4.0 * tol * (min_dist * min_dist_prev) / (min_dist + min_dist_prev) / tree_scale_factor
-                max_search_dist = 3.0 * min_dist
+                max_search_dist = 1.2 * (min_dist + dz * tree_scale_factor)
                 # max_search_dist = 1.0 * hsml[min_index] * tree_scale_factor
                 # if hsml[min_index] < min_dist:
                     # print(hsml[min_index], min_dist, min_dist/tree_scale_factor)
@@ -355,7 +354,7 @@ class RayProjector(ImageCreator):
             if self.parttype == 0:
                 trace_rays = trace_rays_cpu_voronoi
             else:
-                trace_rays =  trace_rays_cpu#_optimized
+                trace_rays =  trace_rays_cpu_optimized
 
             trace_rays(self.tree._pos, self.tree.parents, self.tree.children,
                        self.tree.bounds, variable, hsml, widths, center,

--- a/paicos/image_creators/ray_projector.py
+++ b/paicos/image_creators/ray_projector.py
@@ -45,7 +45,10 @@ def trace_rays_cpu(points, tree_parents, tree_children, tree_bounds, variable, h
                                                            num_internal_nodes)
 
                 # Adaptive step in Arepo units
-                dz = tol * min_dist
+                # dz = tol * hsml[min_index]
+                dz = tol * min_dist / tree_scale_factor
+                # if hsml[min_index] < min_dist:
+                    # print(hsml[min_index], min_dist, min_dist/tree_scale_factor)
                 result += dz * variable[min_index]
                 z += dz
 
@@ -239,6 +242,11 @@ class RayProjector(ImageCreator):
                        self.tree.bounds, variable, hsml, widths, center,
                        tree_scale_factor, tree_offsets, image,
                        rotation_matrix, self.tol)
+        # from ..cython.ray_tracer import trace_rays_cpu as trace_rays_cpu_cython
+        # trace_rays_cpu_cython(self.tree._pos, self.tree.parents, self.tree.children,
+        #        self.tree.bounds, variable, hsml, widths, center,
+        #        tree_scale_factor, tree_offsets, image,
+        #        rotation_matrix, self.tol, 1)
 
         return image
 

--- a/paicos/image_creators/ray_projector.py
+++ b/paicos/image_creators/ray_projector.py
@@ -355,7 +355,7 @@ class RayProjector(ImageCreator):
             if self.parttype == 0:
                 trace_rays = trace_rays_cpu_voronoi
             else:
-                trace_rays =  trace_rays_cpu_optimized
+                trace_rays =  trace_rays_cpu#_optimized
 
             trace_rays(self.tree._pos, self.tree.parents, self.tree.children,
                        self.tree.bounds, variable, hsml, widths, center,

--- a/paicos/image_creators/ray_projector.py
+++ b/paicos/image_creators/ray_projector.py
@@ -124,9 +124,9 @@ def trace_rays_cpu_voronoi(points, tree_parents, tree_children, tree_bounds, var
                                                            tree_bounds, query_point,
                                                            num_internal_nodes)
                 if min_index == -1:
-                    nearest_neighbor_cpu_optimized(points, tree_parents, tree_children,
-                                         tree_bounds, query_point,
-                                         num_internal_nodes, (2**L - 1.0))
+                    min_dist, min_index = nearest_neighbor_cpu_optimized(points, tree_parents, tree_children,
+                                                                         tree_bounds, query_point,
+                                                                         num_internal_nodes, (2**L - 1.0))
                 # Adaptive step in Arepo units
                 dz = tol * hsml[min_index]
                 result += dz * variable[min_index]
@@ -175,9 +175,9 @@ def trace_rays_several_variables_cpu_voronoi(points, tree_parents, tree_children
                                                                    tree_bounds, query_point,
                                                                    num_internal_nodes)
                 if min_index == -1:
-                    nearest_neighbor_cpu_optimized(points, tree_parents, tree_children,
-                                                   tree_bounds, query_point,
-                                                   num_internal_nodes, (2**L - 1.0))
+                    min_dist, min_index = nearest_neighbor_cpu_optimized(points, tree_parents, tree_children,
+                                                                         tree_bounds, query_point,
+                                                                         num_internal_nodes, (2**L - 1.0))
 
                 # Adaptive step in Arepo units
                 dz = tol * hsml[min_index]

--- a/paicos/image_creators/tree_projector.py
+++ b/paicos/image_creators/tree_projector.py
@@ -14,9 +14,10 @@ class TreeProjector(ImageCreator):
     This implements projection of gas variables by adding up several slices.
     """
 
+    @util.conditional_timer
     def __init__(self, snap, center, widths, direction,
                  npix=512, npix_depth=None, parttype=0, make_snap_with_selection=False,
-                 tol=1, verbose=False):
+                 tol=1, verbose=False, timing=False):
 
         """
         Initialize the Slicer object.
@@ -212,7 +213,8 @@ class TreeProjector(ImageCreator):
         """
         return arr.flatten().reshape((self.npix_height, self.npix_width))
 
-    def project_variable(self, variable, additive=True, extrinsic=None):
+    @util.conditional_timer
+    def project_variable(self, variable, additive=True, extrinsic=None, timing=False):
         """
         Project gas variable based on the Voronoi cells closest to each
         line of sight.

--- a/paicos/misc.py
+++ b/paicos/misc.py
@@ -3,6 +3,7 @@ import sys
 import contextlib
 import io
 
+
 @contextlib.contextmanager
 def suppress_omp_nested_warning():
     try:

--- a/paicos/misc.py
+++ b/paicos/misc.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import contextlib
+import io
+
+@contextlib.contextmanager
+def suppress_omp_nested_warning():
+    try:
+        # This works only outside of Jupyter
+        original_stdout_fd = sys.stdout.fileno()
+        original_stderr_fd = sys.stderr.fileno()
+
+        with open(os.devnull, 'w') as devnull:
+            devnull_fd = devnull.fileno()
+
+            # Save original fds
+            saved_stdout = os.dup(original_stdout_fd)
+            saved_stderr = os.dup(original_stderr_fd)
+
+            try:
+                os.dup2(devnull_fd, original_stdout_fd)
+                os.dup2(devnull_fd, original_stderr_fd)
+                yield
+            finally:
+                os.dup2(saved_stdout, original_stdout_fd)
+                os.dup2(saved_stderr, original_stderr_fd)
+                os.close(saved_stdout)
+                os.close(saved_stderr)
+
+    except (io.UnsupportedOperation, AttributeError):
+        # Fallback for Jupyter: suppress Python-level output only
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            yield

--- a/paicos/readers/arepo_snap.py
+++ b/paicos/readers/arepo_snap.py
@@ -644,7 +644,7 @@ class Snapshot(PaicosReader):
             else:
                 unit_str = None
 
-            np_file = int(f["Header"].attrs["NumPart_ThisFile"][parttype])
+            np_file = int(f["Header"].attrs["NumPart_ThisFile"][parttype])  # pylint: disable=unsubscriptable-object
 
             if not self.subselection:
                 if np_file > 0:

--- a/paicos/readers/arepo_snap.py
+++ b/paicos/readers/arepo_snap.py
@@ -639,6 +639,11 @@ class Snapshot(PaicosReader):
 
             f = h5py.File(cur_filename, "r")
 
+            if 'unit' in f[datname].attrs.keys():
+                unit_str = f[datname].attrs['unit']
+            else:
+                unit_str = None
+
             np_file = int(f["Header"].attrs["NumPart_ThisFile"][parttype])
 
             if not self.subselection:
@@ -720,18 +725,21 @@ class Snapshot(PaicosReader):
                 raise RuntimeError('Data has unexpected shape!')
 
         if settings.use_units:
-            if parttype in self._type_info:
-                ptype = self._type_info[parttype]  # e.g. 'voronoi_cells'
-                self[alias_key] = self.get_paicos_quantity(self[alias_key],
-                                                           blockname,
-                                                           field=ptype)
+            if unit_str is not None:
+                self[alias_key] = self[alias_key] * self.unit_quantity(unit_str)
             else:
-                # Assume dark matter for the units
-                self[alias_key] = self.get_paicos_quantity(self[alias_key],
-                                                           blockname,
-                                                           field='dark_matter')
-            if not hasattr(self[alias_key], 'unit'):
-                del self[alias_key]
+                if parttype in self._type_info:
+                    ptype = self._type_info[parttype]  # e.g. 'voronoi_cells'
+                    self[alias_key] = self.get_paicos_quantity(self[alias_key],
+                                                               blockname,
+                                                               field=ptype)
+                else:
+                    # Assume dark matter for the units
+                    self[alias_key] = self.get_paicos_quantity(self[alias_key],
+                                                               blockname,
+                                                               field='dark_matter')
+                if not hasattr(self[alias_key], 'unit'):
+                    del self[alias_key]
 
         if self.verbose:
             print("... done! (took", time.time() - start_time, "s)")

--- a/paicos/trees/bvh_cpu.py
+++ b/paicos/trees/bvh_cpu.py
@@ -394,29 +394,25 @@ def find_nearest_neighbors(points, tree_parents, tree_children, tree_bounds,
 
         if start_id != 0:
             this_query_start_id = int(start_id)
-            # print(this_query_start_id, start_id)
             is_leaf = start_id >= num_internal_nodes
             in_box = is_point_in_box(
                 query_point, tree_bounds[this_query_start_id])
             while not in_box or is_leaf:
-                # print(this_query_start_id, start_id)
+
                 this_query_start_id = tree_parents[this_query_start_id]
-                # print('dfdf')
+
                 in_box = is_point_in_box(
                     query_point, tree_bounds[this_query_start_id])
-                # print('22222')
+
                 is_leaf = this_query_start_id >= num_internal_nodes
-                # print('33333', is_leaf, in_box)
-                # print(this_query_start_id, start_id)
+
+
                 if this_query_start_id == -1:
-                    # print('went all the way up...')
                     this_query_start_id = 0
                     break
         else:
             this_query_start_id = 0
 
-        # print('did we go here?')
-        # print('this_query_start_id', this_query_start_id, start_id)
         # We traverse the nodes and leafs using a while loop and a queue.
 
         # Local memory on each tread (32 should be fine?)
@@ -442,15 +438,6 @@ def find_nearest_neighbors(points, tree_parents, tree_children, tree_bounds,
             point_in_A = is_point_in_box(query_point, tree_bounds[childA])
             point_in_B = is_point_in_box(query_point, tree_bounds[childB])
 
-            # Do explicit check if in a leaf
-            # print(f'node_id: {node_id}\t childA: {childA}\t childB: {childB}\t')
-            # if node_id == 6:
-            #     print('node_id, point_in_A, point_in_B, is_leaf,
-            # is_leafB', node_id, point_in_A, point_in_B, is_leafA, is_leafB)
-            #     print(query_point)
-            #     print(tree_bounds[childA])
-            #     print(tree_bounds[childB])
-            # raise RuntimeError("d")
             if point_in_A and is_leafA:
                 data_id = childA - num_internal_nodes
                 dist = distance(query_point[0],
@@ -460,11 +447,6 @@ def find_nearest_neighbors(points, tree_parents, tree_children, tree_bounds,
                                 points[data_id, 1],
                                 points[data_id, 2])
 
-                # if node_id == 6:
-                #     print(f'dist: {dist}, min_dist: {min_dist}')
-                #     print(dist, min_dist, data_id)
-                #     print(points[data_id], query_point)
-                # raise RuntimeError("d")
                 if dist < min_dist:
                     min_dist = dist
                     min_index = data_id

--- a/paicos/trees/bvh_gpu.py
+++ b/paicos/trees/bvh_gpu.py
@@ -295,6 +295,10 @@ def distance_to_box(point, box):
 @cuda.jit(device=True, inline=True)
 def nearest_neighbor_device(points, tree_parents, tree_children, tree_bounds,
                             query_point, num_internal_nodes):
+    """
+    This is a nearest neighbor function which is fast and which
+    works well on Voronoi cells.
+    """
 
     # We traverse the nodes and leafs using a while loop and a queue.
     # Local memory on each tread (32 should be fine?)
@@ -318,11 +322,11 @@ def nearest_neighbor_device(points, tree_parents, tree_children, tree_bounds,
         is_leafA = childA >= num_internal_nodes
         is_leafB = childB >= num_internal_nodes
 
-        # point_in_A = is_point_in_box(query_point, tree_bounds[childA])
-        # point_in_B = is_point_in_box(query_point, tree_bounds[childB])
+        point_in_A = is_point_in_box(query_point, tree_bounds[childA])
+        point_in_B = is_point_in_box(query_point, tree_bounds[childB])
 
         # Do explicit check if in a leaf
-        if is_leafA:
+        if point_in_A and is_leafA:
             data_id = childA - num_internal_nodes
             dist = distance(points[data_id], query_point)
 
@@ -330,7 +334,7 @@ def nearest_neighbor_device(points, tree_parents, tree_children, tree_bounds,
                 min_dist = dist
                 min_index = data_id
 
-        if is_leafB:
+        if point_in_B and is_leafB:
             data_id = childB - num_internal_nodes
             dist = distance(points[data_id], query_point)
 
@@ -339,12 +343,8 @@ def nearest_neighbor_device(points, tree_parents, tree_children, tree_bounds,
                 min_index = data_id
 
         # Whether to traverse
-        distA = distance_to_box(query_point, tree_bounds[childA])
-        distB = distance_to_box(query_point, tree_bounds[childB])
-
-        # Whether to traverse
-        traverseA = (distA <= min_dist) and not is_leafA
-        traverseB = (distB <= min_dist) and not is_leafB
+        traverseA = point_in_A and not is_leafA
+        traverseB = point_in_B and not is_leafB
 
         if (not traverseA) and (not traverseB):
             queue_index -= 1
@@ -363,6 +363,11 @@ def nearest_neighbor_device(points, tree_parents, tree_children, tree_bounds,
 @cuda.jit(device=True, inline=True)
 def nearest_neighbor_device_optimized(points, tree_parents, tree_children, tree_bounds,
                             query_point, num_internal_nodes, min_dist_init):
+    """
+    This is a nearest neighbor function that works for general particle distributions,
+    i.e., the points are *not* assumed to have overlapping bounding volumes that
+    fill space with no holes.
+    """
 
     # We traverse the nodes and leafs using a while loop and a queue.
     # Local memory on each tread (32 should be fine?)
@@ -378,16 +383,12 @@ def nearest_neighbor_device_optimized(points, tree_parents, tree_children, tree_
     while queue_index >= 0:
 
         node_id = queue[queue_index]
-        # print(queue_index, node_id)#traverseA, traverseB, is_leafA, is_leafB)
 
         childA = tree_children[node_id, 0]
         childB = tree_children[node_id, 1]
 
         is_leafA = childA >= num_internal_nodes
         is_leafB = childB >= num_internal_nodes
-
-        # point_in_A = is_point_in_box(query_point, tree_bounds[childA])
-        # point_in_B = is_point_in_box(query_point, tree_bounds[childB])
 
         # Do explicit check if in a leaf
         if is_leafA:

--- a/paicos/trees/bvh_gpu.py
+++ b/paicos/trees/bvh_gpu.py
@@ -78,13 +78,9 @@ def delta(sortedMortonCodes, i, j):
     else:
         return cuda.libdevice.clzll(codeA ^ codeB)
 
+
 @cuda.jit(device=True, inline=True)
 def findSplit(sortedMortonCodes, first, last):
-    # Identical Morton codes => split the range in the middle.
-
-    firstCode = sortedMortonCodes[first]
-    lastCode = sortedMortonCodes[last]
-
     # Calculate the number of highest bits that are the same
     # for all objects, using the count-leading-zeros intrinsic.
 
@@ -278,6 +274,7 @@ def is_point_in_box(point, box):
             return False
     return True
 
+
 @cuda.jit(device=True, inline=True)
 def distance_to_box(point, box):
     """Squared distance from a point to an AABB (0 if inside)."""
@@ -362,7 +359,7 @@ def nearest_neighbor_device(points, tree_parents, tree_children, tree_bounds,
 
 @cuda.jit(device=True, inline=True)
 def nearest_neighbor_device_optimized(points, tree_parents, tree_children, tree_bounds,
-                            query_point, num_internal_nodes, min_dist_init):
+                                      query_point, num_internal_nodes, min_dist_init):
     """
     This is a nearest neighbor function that works for general particle distributions,
     i.e., the points are *not* assumed to have overlapping bounding volumes that

--- a/paicos/trees/bvh_tree.pyx
+++ b/paicos/trees/bvh_tree.pyx
@@ -1,8 +1,23 @@
 import cython
 import numpy as np
+cimport numpy as np
+from cython.parallel import prange
+from libc.math cimport fmin, fmax
+from libc.math cimport ceil
+cimport cython
+from libc.stdlib cimport malloc, free
+from libc.string cimport memset
 
-cdef extern int __builtin_clzl(unsigned long x)
+ctypedef np.int32_t int32_t
+ctypedef np.int64_t int64_t
 
+
+ctypedef unsigned long ulong
+ctypedef double real_t
+
+cdef extern int __builtin_clzl(unsigned long x) nogil
+
+cdef int L = 21
 
 def leading_zeros_cython(unsigned long x):
     return __builtin_clzl(x)
@@ -17,3 +32,264 @@ def get_leading_zeros(unsigned long[:] morton_keys):
     tmp = np.zeros(N, dtype=np.int32)
     tmp[:] = my_leading_zeros[:]
     return tmp
+
+def set_leaf_bounding_volumes(ulong[:, :, :] tree_bounds,
+                               real_t[:, :] points,
+                               real_t[:] half_size,
+                               real_t conversion_factor,
+                               ulong L):
+    # cdef ulong L = 21
+    cdef Py_ssize_t ip
+    cdef Py_ssize_t num_leafs = half_size.shape[0]
+    cdef Py_ssize_t num_internal_nodes = num_leafs - 1
+
+    cdef real_t f = conversion_factor
+    cdef real_t cx, cy, cz, hs
+    cdef ulong max_index = (<ulong>1 << L) - 1
+    cdef ulong x_min, y_min, z_min, x_max, y_max, z_max
+
+    with nogil:
+        for ip in prange(num_leafs, schedule='static'):
+            hs = f * half_size[ip]
+            cx = points[ip, 0]
+            cy = points[ip, 1]
+            cz = points[ip, 2]
+
+            x_min = <ulong> max(cx - hs, 0.0)
+            y_min = <ulong> max(cy - hs, 0.0)
+            z_min = <ulong> max(cz - hs, 0.0)
+
+            x_max = <ulong> min(ceil(cx + hs), max_index)
+            y_max = <ulong> min(ceil(cy + hs), max_index)
+            z_max = <ulong> min(ceil(cz + hs), max_index)
+
+            tree_bounds[ip + num_internal_nodes, 0, 0] = x_min
+            tree_bounds[ip + num_internal_nodes, 1, 0] = y_min
+            tree_bounds[ip + num_internal_nodes, 2, 0] = z_min
+            tree_bounds[ip + num_internal_nodes, 0, 1] = x_max
+            tree_bounds[ip + num_internal_nodes, 1, 1] = y_max
+            tree_bounds[ip + num_internal_nodes, 2, 1] = z_max
+
+
+
+def propagate_bounds_upwards(ulong[:, :, :] tree_bounds,
+                             int64_t[:] tree_parents,
+                             int64_t[:, :] tree_children):
+    cdef int num_internal_nodes = tree_children.shape[0]
+    cdef int num_leafs = num_internal_nodes + 1
+    cdef int num_total_nodes = num_internal_nodes + num_leafs
+
+    cdef int64_t *queue = <int64_t *> malloc(num_total_nodes * sizeof(int64_t))
+    cdef int64_t *next_queue = <int64_t *> malloc(num_total_nodes * sizeof(int64_t))
+    cdef int *seen = <int *> malloc(num_total_nodes * sizeof(int))
+    cdef int *child_counter = <int *> malloc(num_total_nodes * sizeof(int))
+    memset(seen, 0, num_total_nodes * sizeof(int))
+    memset(child_counter, 0, num_total_nodes * sizeof(int))
+
+    cdef int i, node_id, parent_id
+    cdef int queue_len = 0
+    cdef int next_len = 0
+
+    # Queue initialization: find unique parents of leaves
+    for i in range(num_leafs):
+        node_id = num_internal_nodes + i
+        parent_id = tree_parents[node_id]
+        if parent_id >= 0:
+            child_counter[parent_id] += 1
+
+    for i in range(num_internal_nodes):
+        if child_counter[i] == 2:
+            seen[i] = 1
+            queue[queue_len] = i
+            queue_len += 1
+
+    cdef ulong[:, :, :] bounds = tree_bounds
+    cdef int64_t[:] parents = tree_parents
+    cdef int64_t[:, :] children = tree_children
+    cdef int childA, childB, dim
+    cdef ulong a_min, b_min, a_max, b_max
+
+    while queue_len > 0:
+        next_len = 0
+        for i in range(queue_len):
+            node_id = queue[i]
+            parent_id = parents[node_id]
+            if parent_id >= 0:
+                child_counter[parent_id] += 1
+                if child_counter[parent_id] == 2 and seen[parent_id] == 0:
+                    seen[parent_id] = 1
+                    next_queue[next_len] = parent_id
+                    next_len += 1
+
+            childA = children[node_id, 0]
+            childB = children[node_id, 1]
+
+            for dim in range(3):
+                a_min = bounds[childA, dim, 0]
+                b_min = bounds[childB, dim, 0]
+                a_max = bounds[childA, dim, 1]
+                b_max = bounds[childB, dim, 1]
+                bounds[node_id, dim, 0] = min(a_min, b_min)
+                bounds[node_id, dim, 1] = max(a_max, b_max)
+
+        queue_len = next_len
+        tmp = queue
+        queue = next_queue
+        next_queue = tmp
+
+    free(queue)
+    free(next_queue)
+    free(seen)
+    free(child_counter)
+
+cdef inline int count_leading_zeros(unsigned long x) noexcept nogil:
+    return __builtin_clzl(x)
+
+cdef inline ulong part1by2_64(ulong n) noexcept nogil:
+    n &= <ulong>0x1fffff
+    n = (n | (n << 32)) & <ulong>0x1f00000000ffff
+    n = (n | (n << 16)) & <ulong>0x1f0000ff0000ff
+    n = (n | (n << 8)) & <ulong>0x100f00f00f00f00f
+    n = (n | (n << 4)) & <ulong>0x10c30c30c30c30c3
+    n = (n | (n << 2)) & <ulong>0x1249249249249249
+    return n
+
+cdef inline ulong unpart1by2_64(ulong n) noexcept nogil:
+    n &= <ulong>0x1249249249249249
+    n = (n ^ (n >> 2)) & <ulong>0x10c30c30c30c30c3
+    n = (n ^ (n >> 4)) & <ulong>0x100f00f00f00f00f
+    n = (n ^ (n >> 8)) & <ulong>0x1f0000ff0000ff
+    n = (n ^ (n >> 16)) & <ulong>0x1f00000000ffff
+    n = (n ^ (n >> 32)) & <ulong>0x1fffff
+    return n
+
+cdef inline ulong encode64(ulong x, ulong y, ulong z) noexcept nogil:
+    return 4 * part1by2_64(x) + 2 * part1by2_64(y) + part1by2_64(z)
+
+
+cdef inline void decode64(ulong key, ulong[:] out) noexcept nogil:
+    out[0] = unpart1by2_64(key >> 2)
+    out[1] = unpart1by2_64(key >> 1)
+    out[2] = unpart1by2_64(key)
+
+def get_morton_keys64(ulong[:, :] pos):
+    cdef Py_ssize_t N = pos.shape[0]
+    cdef ulong[:] morton_keys = np.empty(N, dtype=np.uint64)
+    cdef Py_ssize_t i
+    for i in range(N):
+        morton_keys[i] = encode64(<ulong>pos[i,0], <ulong>pos[i,1], <ulong>pos[i,2])
+
+    tmp = np.empty(N, dtype=np.uint64)
+    tmp[:] = morton_keys[:]
+    return tmp
+
+cdef inline int findSplit(ulong[:] sortedMortonCodes, int first, int last) noexcept nogil:
+    cdef ulong firstCode = sortedMortonCodes[first]
+    cdef ulong lastCode = sortedMortonCodes[last]
+    cdef int commonPrefix, step, split, newSplit, splitPrefix
+
+    if firstCode == lastCode:
+        return (first + last) >> 1
+
+    commonPrefix = count_leading_zeros(firstCode ^ lastCode)
+    split = first
+    step = last - first
+
+    while step > 1:
+        step = (step + 1) >> 1
+        newSplit = split + step
+        if newSplit < last:
+            splitPrefix = count_leading_zeros(firstCode ^ sortedMortonCodes[newSplit])
+            if splitPrefix > commonPrefix:
+                split = newSplit
+    return split
+
+cdef inline void determineRange(ulong[:] sortedMortonCodes, int n_codes, int idx, int[:] first_last) noexcept nogil:
+    cdef int d = 1, minPrefixLength = -1
+    cdef int firstIndex = idx, max_last = n_codes
+    cdef int lz_p1, lz_m1, lz_first_second, searchRange, secondIndex, newJdx
+    cdef int first, last
+    cdef ulong p1, m1
+
+    if (firstIndex > 0):
+        p1 = sortedMortonCodes[firstIndex] ^ sortedMortonCodes[firstIndex + 1]
+        m1 = sortedMortonCodes[firstIndex] ^ sortedMortonCodes[firstIndex - 1]
+
+        # Count leading zeros
+        lz_p1 = count_leading_zeros(p1)
+        lz_m1 = count_leading_zeros(m1)
+
+        if lz_p1 > lz_m1:
+            d = 1
+            minPrefixLength = lz_m1
+        else:
+            d = -1
+            minPrefixLength = lz_p1
+
+    searchRange = 2
+    secondIndex = firstIndex + searchRange * d
+
+    while (0 <= secondIndex and secondIndex < max_last):
+        lz_first_second = count_leading_zeros(
+            sortedMortonCodes[firstIndex] ^ sortedMortonCodes[secondIndex])
+        if lz_first_second > minPrefixLength:
+            searchRange *= 2
+            secondIndex = firstIndex + searchRange * d
+            if (0 <= secondIndex and secondIndex < max_last):
+                lz_first_second = count_leading_zeros(
+                    sortedMortonCodes[firstIndex] ^ sortedMortonCodes[secondIndex])
+            else:
+                break
+        else:
+            break
+
+    # start binary search with known searchRange
+    secondIndex = firstIndex
+    while searchRange > 1:
+        searchRange = (searchRange + 1) // 2
+        newJdx = secondIndex + searchRange * d
+        if (0 <= newJdx and newJdx < max_last):
+            lz_f_Jdx = count_leading_zeros(
+                sortedMortonCodes[firstIndex] ^ sortedMortonCodes[newJdx])
+            if lz_f_Jdx > minPrefixLength:
+                secondIndex = newJdx
+
+    first = min(secondIndex, firstIndex)
+    last = max(secondIndex, firstIndex)
+    first_last[0] = first
+    first_last[1] = last
+
+def generateHierarchy(ulong[:] sortedMortonCodes, long[:, :] tree_children, long[:] tree_parents):
+    cdef int n_codes = sortedMortonCodes.shape[0]
+    cdef int num_internal_nodes = n_codes - 1
+    cdef int idx, first, last, split
+    cdef int childA, childB
+
+    cdef int[:] first_last = np.empty(2, dtype=np.int32)
+    # cdef int[2] first_last
+
+    for idx in range(num_internal_nodes):
+        determineRange(sortedMortonCodes, n_codes, idx, first_last)
+        first = first_last[0]
+        last = first_last[1]
+        split = findSplit(sortedMortonCodes, first, last)
+
+        # Select childA
+        if split == first:
+            # Is a leaf
+            childA = split + num_internal_nodes
+        else:
+            # Is in an internal node
+            childA = split
+
+        # Select childB
+        if split + 1 == last:
+            childB = split + 1 + num_internal_nodes
+        else:
+            childB = split + 1
+
+        # Set children and parent
+        tree_children[idx, 0] = childA
+        tree_children[idx, 1] = childB
+        tree_parents[childA] = idx
+        tree_parents[childB] = idx

--- a/paicos/trees/bvh_tree.pyx
+++ b/paicos/trees/bvh_tree.pyx
@@ -1,6 +1,7 @@
 import cython
 import numpy as np
 cimport numpy as np
+np.import_array()
 from cython.parallel import prange
 from libc.math cimport fmin, fmax
 from libc.math cimport ceil
@@ -21,6 +22,12 @@ cdef int L = 21
 
 def leading_zeros_cython(unsigned long x):
     return __builtin_clzl(x)
+
+cdef api long leading_zeros_cython_for_numba(unsigned long x):
+    return <long>(__builtin_clzl(x))
+
+def get_len_of_common_prefix_cython(ulong key1, ulong key2):
+    return __builtin_clzl(key1 ^ key2)
 
 def get_leading_zeros(unsigned long[:] morton_keys):
     cdef int ii, N
@@ -166,6 +173,8 @@ cdef inline ulong unpart1by2_64(ulong n) noexcept nogil:
 cdef inline ulong encode64(ulong x, ulong y, ulong z) noexcept nogil:
     return 4 * part1by2_64(x) + 2 * part1by2_64(y) + part1by2_64(z)
 
+def encode64_cython(ulong x, ulong y, ulong z):
+    return 4 * part1by2_64(x) + 2 * part1by2_64(y) + part1by2_64(z)
 
 cdef inline void decode64(ulong key, ulong[:] out) noexcept nogil:
     out[0] = unpart1by2_64(key >> 2)

--- a/paicos/trees/compare_cython_and_numba_implementations.py
+++ b/paicos/trees/compare_cython_and_numba_implementations.py
@@ -1,0 +1,100 @@
+import paicos as pa
+import numpy as np
+from scipy.spatial import KDTree
+pa.use_units(False)
+from paicos.trees.bvh_cpu import BinaryTree
+snap = pa.Snapshot(pa.data_dir, 247, basename='reduced_snap',
+                   load_catalog=False)
+center = np.array([398968.4, 211682.6, 629969.9])
+widths = np.array([2000, 2000, 2000])
+
+# Select a cube
+index = pa.util.get_index_of_cubic_region_plus_thin_layer(
+    snap['0_Coordinates'], center, widths,
+    snap['0_Diameters'], snap.box)
+
+snap = snap.select(index, parttype=0)
+
+pos = snap['0_Coordinates']
+sizes = snap['0_Diameters']
+
+L = 21
+
+positions = pos
+sizes = 1.2 * sizes
+
+_pos = np.array(positions)
+
+# Convert _position to units from [0, 1) * 2**L
+off_sets = np.min(_pos, axis=0)
+_pos -= off_sets[None, :]
+
+max_pos = np.max(_pos)
+conversion_factor = (2**L - 1) / max_pos
+_pos *= conversion_factor
+
+# if use_units take the value...
+# pos = pos.value
+#
+
+# Calculate uint64 and Morton keys
+_pos_uint = _pos.astype(np.uint64)
+from paicos.trees.bvh_cpu import get_morton_keys64_old, get_morton_keys64
+
+morton_keys_old = get_morton_keys64_old(_pos_uint)
+morton_keys = get_morton_keys64(_pos_uint)
+
+np.testing.assert_array_equal(morton_keys, morton_keys_old)
+# print(morton_keys)
+
+# Store index for going back to original ids.
+sort_index = np.argsort(morton_keys)
+
+# Do the sorting
+morton_keys = morton_keys[sort_index]
+_pos = _pos[sort_index, :]
+_pos_uint = _pos_uint[sort_index, :]
+
+# # Some tree properties
+num_leafs = morton_keys.shape[0]
+num_internal_nodes = num_leafs - 1
+num_leafs_and_nodes = 2 * num_leafs - 1
+
+
+from paicos.trees.bvh_cpu import generateHierarchy_old, generateHierarchy
+# Allocate arrays
+children = -1 * np.ones((num_internal_nodes, 2), dtype=int)
+parents = -1 * np.ones(num_leafs_and_nodes, dtype=int)
+
+children_old = -1 * np.ones((num_internal_nodes, 2), dtype=int)
+parents_old = -1 * np.ones(num_leafs_and_nodes, dtype=int)
+
+from paicos.trees.bvh_cpu import generateHierarchy_old, generateHierarchy
+
+# # This sets the parent and children properties
+generateHierarchy(morton_keys, children, parents)
+generateHierarchy_old(morton_keys, children_old, parents_old)
+
+np.testing.assert_array_equal(parents, parents_old)
+np.testing.assert_array_equal(children, children_old)
+
+# Set the boundaries for the leafs
+bounds_old = np.zeros((num_leafs_and_nodes, 3, 2), dtype=np.uint64)
+bounds = np.zeros((num_leafs_and_nodes, 3, 2), dtype=np.uint64)
+bounds_cython = np.zeros((num_leafs_and_nodes, 3, 2), dtype=np.uint64)
+
+from paicos.trees.bvh_cpu import set_leaf_bounding_volumes_old, set_leaf_bounding_volumes
+set_leaf_bounding_volumes_old(bounds_old, _pos,
+                          sizes[sort_index],
+                          conversion_factor)
+set_leaf_bounding_volumes(bounds, _pos,
+                          sizes[sort_index],
+                          conversion_factor, L)
+
+np.testing.assert_array_equal(bounds, bounds_old)
+
+from paicos.trees.bvh_cpu import propagate_bounds_upwards_old, propagate_bounds_upwards
+propagate_bounds_upwards_old(bounds_old, parents, children)
+propagate_bounds_upwards(bounds, parents, children)
+
+np.testing.assert_array_equal(bounds, bounds_old)

--- a/paicos/util.py
+++ b/paicos/util.py
@@ -375,8 +375,10 @@ def _check_if_omp_has_issues(verbose=True):
     if settings.give_openMP_warnings is False:
         verbose = False
 
-    max_threads = get_openmp_settings(0, False)
+    # max_threads = get_openmp_settings(0, True)
+    max_threads = os.cpu_count()
     settings.max_threads = max_threads
+
     if settings.numthreads > max_threads and verbose:
         msg = ('\n\nThe default number of OpenMP threads, {}, '
                + 'exceeds the {} available on your system. Setting '

--- a/paicos/util.py
+++ b/paicos/util.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import h5py
 from functools import wraps
+import time
 from . import settings
 from . import units as pu
 from .cython.get_index_of_region import get_cube, get_radial_range
@@ -421,3 +422,23 @@ def _copy_over_snapshot_information(snap, new_filename, mode='r+'):
             f.create_group(group)
             for key in info_dic[group]:
                 f[group].attrs[key] = info_dic[group][key]
+
+
+def conditional_timer(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        timing = kwargs.pop('timing', False)
+        if timing:
+            start = time.perf_counter()
+            result = func(*args, **kwargs)
+            end = time.perf_counter()
+
+            class_info = ""
+            if args and hasattr(args[0], '__class__'):
+                class_info = f"{args[0].__class__.__name__}."
+
+            print(f"[TIMER] {class_info}{func.__name__} took {end - start:.6f} seconds")
+            return result
+        else:
+            return func(*args, **kwargs)
+    return wrapper

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import glob
 #     os.environ['CC'] = 'gcc-13'
 #     os.environ['CXX'] = 'g++-13'
 
-Options.annotate = False
+Options.annotate = True
 compiler_directives = {"boundscheck": False, "cdivision": True,
                        "wraparound": False, 'language_level': "3"}
 
@@ -67,8 +67,14 @@ ext_modules = [
         include_dirs=include_dirs,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args
+    ),
+    Extension(
+        name='paicos.cython.ray_tracer',
+        sources=['paicos/cython/ray_tracer.pyx'],
+        include_dirs=include_dirs,
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args
     )
-
 ]
 
 install_requires = ['scipy',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import glob
 #     os.environ['CXX'] = 'g++-13'
 
 Options.annotate = True
-compiler_directives = {"boundscheck": False, "cdivision": True, "nonecheck":False,
+compiler_directives = {"boundscheck": False, "cdivision": True, "nonecheck": False,
                        "wraparound": False, 'language_level': "3"}
 # compiler_directives = {"boundscheck": True, "cdivision": True,
 #                        "wraparound": False, 'language_level': "3"}

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,15 @@ import glob
 #     os.environ['CXX'] = 'g++-13'
 
 Options.annotate = True
-compiler_directives = {"boundscheck": False, "cdivision": True,
+compiler_directives = {"boundscheck": False, "cdivision": True, "nonecheck":False,
                        "wraparound": False, 'language_level': "3"}
+# compiler_directives = {"boundscheck": True, "cdivision": True,
+#                        "wraparound": False, 'language_level': "3"}
 
 
 include_dirs = ['paicos/cython/', numpy.get_include()]
 extra_compile_args = ['-fopenmp', "-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION",
-                      "-Wno-unused-function"]
+                      "-Wno-unused-function", '-O3', '-ffast-math', '-march=native']
 extra_link_args = ['-fopenmp']
 ext_modules = [
     Extension(

--- a/tests/cuda-gpu/test_gpu_ray_projector.py
+++ b/tests/cuda-gpu/test_gpu_ray_projector.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_gpu_ray_projector(show=False):
+def test_gpu_ray_projector(show=False, timing=False):
     """
     We compare the CPU and GPU implementations of ray-tracing.
     """
@@ -36,14 +36,14 @@ def test_gpu_ray_projector(show=False):
 
     # Initialize projectors
     tree_projector = pa.TreeProjector(snap, center, widths, orientation, npix=npix,
-                                      tol=0.25)
+                                      tol=0.25, timing=timing)
     gpu_projector = pa.GpuRayProjector(snap, center, widths, orientation, npix=npix,
                                        threadsperblock=8, do_pre_selection=True,
-                                       tol=0.25)
+                                       tol=0.25, timing=timing)
 
     # Project density
-    tree_dens = tree_projector.project_variable('0_Density', additive=False)
-    gpu_dens = gpu_projector.project_variable('0_Density', additive=False)
+    tree_dens = tree_projector.project_variable('0_Density', additive=False, timing=timing)
+    gpu_dens = gpu_projector.project_variable('0_Density', additive=False, timing=timing)
 
     max_rel_err = np.max(np.abs(tree_dens.value - gpu_dens.value) / tree_dens.value)
 
@@ -68,4 +68,4 @@ def test_gpu_ray_projector(show=False):
 
 
 if __name__ == '__main__':
-    test_gpu_ray_projector(True)
+    test_gpu_ray_projector(True, True)

--- a/tests/non-comoving/test_tree_projector_vs_ray_projector.py
+++ b/tests/non-comoving/test_tree_projector_vs_ray_projector.py
@@ -1,70 +1,69 @@
 
-# def test_tree_projector_vs_ray_projector(show=False):
-show = True
-import paicos as pa
-import numpy as np
+def test_tree_projector_vs_ray_projector(show=False):
+    show = True
+    import paicos as pa
+    import numpy as np
+
+    pa.numthreads(pa.settings.max_threads)
+    snap = pa.Snapshot(pa.data_dir, 7,
+                       basename='small_non_comoving')
+
+    widths = snap.box_size.copy
+    center = snap.box_size.copy / 2
+
+    widths[2] = widths[2]
+
+    tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300, tol=0.1)
+    projector = pa.RayProjector(snap, center, widths, 'z', npix=300, tol=0.1, use_numba=True)
+
+    # tree_M = tree_projector.project_variable('0_Masses')
+    # tree_V = tree_projector.project_variable('0_Volume')
+    # tree_rho = tree_M / tree_V
+    tree_rho = tree_projector.project_variable('0_Density', additive=False)
+
+    rho = projector.project_variable('0_Density', additive=False)
+    # V = projector.project_variable('0_Volume', additive=False)
+    # rho = M / V
+
+    rel_rho = (np.abs(tree_rho - rho) / tree_rho)
+    print(np.sqrt(np.mean(rel_rho**2)))
+    # rel_M = (np.abs(tree_M - M) / tree_M)
+
+    # assert np.max(rel_rho.value) < 0.17, np.max(rel_rho.value)
+
+    # Only check away from boundaries since we do not do these correctly
+    # with the SPH projector.
+    # M_err = np.max(rel_M[35:65, 100:200])
+    # assert M_err < 0.16, M_err
+
+    if show:
+        import matplotlib.pyplot as plt
+
+        plt.figure(1)
+        plt.clf()
+        fig, axes = plt.subplots(num=1, nrows=3, sharex=True)
+
+        # Define new imshow_wo_units that automatically plots the values
+        fig.suptitle('Density plots')
+        imshow_wo_units = pa.util.remove_astro_units(axes[0].imshow)
+        imshow_wo_units(rho, extent=projector.extent,
+                        vmin=rho.min(), vmax=rho.max())
+        axes[0].set_ylabel(projector.extent.label('y'))
+        axes[0].set_title('RayProjector')
+
+        imshow_wo_units = pa.util.remove_astro_units(axes[1].imshow)
+        imshow_wo_units(tree_rho.value, extent=tree_projector.extent.value,
+                        vmin=tree_rho.min(), vmax=tree_rho.max())
+        axes[1].set_ylabel(tree_projector.extent.label('y'))
+        axes[1].set_title('TreeProjector')
+
+        axes[2].imshow(rel_rho.value, extent=tree_projector.extent.value)
+        axes[2].set_ylabel(tree_projector.extent.label('y'))
+        axes[2].set_xlabel(tree_projector.extent.label('x'))
+        axes[2].set_title('Rel difference')
+
+        plt.show()
 
 
-pa.numthreads(pa.settings.max_threads)
-snap = pa.Snapshot(pa.data_dir, 7,
-                   basename='small_non_comoving')
-
-widths = snap.box_size.copy
-center = snap.box_size.copy / 2
-
-widths[2] = widths[2]
-
-tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300, tol=0.1)
-projector = pa.RayProjector(snap, center, widths, 'z', npix=300, tol=0.1, use_numba=True)
-
-# tree_M = tree_projector.project_variable('0_Masses')
-# tree_V = tree_projector.project_variable('0_Volume')
-# tree_rho = tree_M / tree_V
-tree_rho = tree_projector.project_variable('0_Density', additive=False)
-
-rho = projector.project_variable('0_Density', additive=False)
-# V = projector.project_variable('0_Volume', additive=False)
-# rho = M / V
-
-rel_rho = (np.abs(tree_rho - rho) / tree_rho)
-print(np.sqrt(np.mean(rel_rho**2)))
-# rel_M = (np.abs(tree_M - M) / tree_M)
-
-# assert np.max(rel_rho.value) < 0.17, np.max(rel_rho.value)
-
-# Only check away from boundaries since we do not do these correctly
-# with the SPH projector.
-# M_err = np.max(rel_M[35:65, 100:200])
-# assert M_err < 0.16, M_err
-
-if show:
-    import matplotlib.pyplot as plt
-
-    plt.figure(1)
-    plt.clf()
-    fig, axes = plt.subplots(num=1, nrows=3, sharex=True)
-
-    # Define new imshow_wo_units that automatically plots the values
-    fig.suptitle('Density plots')
-    imshow_wo_units = pa.util.remove_astro_units(axes[0].imshow)
-    imshow_wo_units(rho, extent=projector.extent,
-                    vmin=rho.min(), vmax=rho.max())
-    axes[0].set_ylabel(projector.extent.label('y'))
-    axes[0].set_title('RayProjector')
-
-    imshow_wo_units = pa.util.remove_astro_units(axes[1].imshow)
-    imshow_wo_units(tree_rho.value, extent=tree_projector.extent.value,
-                    vmin=tree_rho.min(), vmax=tree_rho.max())
-    axes[1].set_ylabel(tree_projector.extent.label('y'))
-    axes[1].set_title('TreeProjector')
-
-    axes[2].imshow(rel_rho.value, extent=tree_projector.extent.value)
-    axes[2].set_ylabel(tree_projector.extent.label('y'))
-    axes[2].set_xlabel(tree_projector.extent.label('x'))
-    axes[2].set_title('Rel difference')
-
-    plt.show()
-
-
-# if __name__ == '__main__':
-#     test_tree_projector_vs_ray_projector(True)
+if __name__ == '__main__':
+    test_tree_projector_vs_ray_projector(True)

--- a/tests/non-comoving/test_tree_projector_vs_ray_projector.py
+++ b/tests/non-comoving/test_tree_projector_vs_ray_projector.py
@@ -1,0 +1,64 @@
+
+def test_tree_projector_vs_ray_projector(show=False):
+    import paicos as pa
+    import numpy as np
+
+    snap = pa.Snapshot(pa.data_dir, 7,
+                       basename='small_non_comoving')
+
+    widths = snap.box_size.copy
+    center = snap.box_size.copy / 2
+
+    tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300)
+    projector = pa.RayProjector(snap, center, widths, 'z', npix=300)
+
+    # tree_M = tree_projector.project_variable('0_Masses')
+    # tree_V = tree_projector.project_variable('0_Volume')
+    # tree_rho = tree_M / tree_V
+    tree_rho = tree_projector.project_variable('0_Density', additive=False)
+
+    rho = projector.project_variable('0_Density', additive=False)
+    # V = projector.project_variable('0_Volume', additive=False)
+    # rho = M / V
+
+    rel_rho = (np.abs(tree_rho - rho) / tree_rho)
+    # rel_M = (np.abs(tree_M - M) / tree_M)
+
+    # assert np.max(rel_rho.value) < 0.17, np.max(rel_rho.value)
+
+    # Only check away from boundaries since we do not do these correctly
+    # with the SPH projector.
+    # M_err = np.max(rel_M[35:65, 100:200])
+    # assert M_err < 0.16, M_err
+
+    if show:
+        import matplotlib.pyplot as plt
+
+        plt.figure(1)
+        plt.clf()
+        fig, axes = plt.subplots(num=1, nrows=3, sharex=True)
+
+        # Define new imshow_wo_units that automatically plots the values
+        fig.suptitle('Density plots')
+        imshow_wo_units = pa.util.remove_astro_units(axes[0].imshow)
+        imshow_wo_units(rho, extent=projector.extent,
+                        vmin=rho.min(), vmax=rho.max())
+        axes[0].set_ylabel(projector.extent.label('y'))
+        axes[0].set_title('RayProjector')
+
+        imshow_wo_units = pa.util.remove_astro_units(axes[1].imshow)
+        imshow_wo_units(tree_rho.value, extent=tree_projector.extent.value,
+                        vmin=rho.min(), vmax=rho.max())
+        axes[1].set_ylabel(tree_projector.extent.label('y'))
+        axes[1].set_title('TreeProjector')
+
+        axes[2].imshow(rel_rho.value, extent=tree_projector.extent.value)
+        axes[2].set_ylabel(tree_projector.extent.label('y'))
+        axes[2].set_xlabel(tree_projector.extent.label('x'))
+        axes[2].set_title('Rel difference')
+
+        plt.show()
+
+
+if __name__ == '__main__':
+    test_tree_projector_vs_ray_projector(True)

--- a/tests/non-comoving/test_tree_projector_vs_ray_projector.py
+++ b/tests/non-comoving/test_tree_projector_vs_ray_projector.py
@@ -4,14 +4,18 @@ show = True
 import paicos as pa
 import numpy as np
 
+
+pa.numthreads(pa.settings.max_threads)
 snap = pa.Snapshot(pa.data_dir, 7,
                    basename='small_non_comoving')
 
 widths = snap.box_size.copy
 center = snap.box_size.copy / 2
 
-tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300)
-projector = pa.RayProjector(snap, center, widths, 'z', npix=300, tol=2)
+widths[2] = widths[2]
+
+tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300, tol=0.1)
+projector = pa.RayProjector(snap, center, widths, 'z', npix=300, tol=0.1, use_numba=True)
 
 # tree_M = tree_projector.project_variable('0_Masses')
 # tree_V = tree_projector.project_variable('0_Volume')
@@ -23,6 +27,7 @@ rho = projector.project_variable('0_Density', additive=False)
 # rho = M / V
 
 rel_rho = (np.abs(tree_rho - rho) / tree_rho)
+print(np.sqrt(np.mean(rel_rho**2)))
 # rel_M = (np.abs(tree_M - M) / tree_M)
 
 # assert np.max(rel_rho.value) < 0.17, np.max(rel_rho.value)

--- a/tests/non-comoving/test_tree_projector_vs_ray_projector.py
+++ b/tests/non-comoving/test_tree_projector_vs_ray_projector.py
@@ -1,64 +1,65 @@
 
-def test_tree_projector_vs_ray_projector(show=False):
-    import paicos as pa
-    import numpy as np
+# def test_tree_projector_vs_ray_projector(show=False):
+show = True
+import paicos as pa
+import numpy as np
 
-    snap = pa.Snapshot(pa.data_dir, 7,
-                       basename='small_non_comoving')
+snap = pa.Snapshot(pa.data_dir, 7,
+                   basename='small_non_comoving')
 
-    widths = snap.box_size.copy
-    center = snap.box_size.copy / 2
+widths = snap.box_size.copy
+center = snap.box_size.copy / 2
 
-    tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300)
-    projector = pa.RayProjector(snap, center, widths, 'z', npix=300)
+tree_projector = pa.TreeProjector(snap, center, widths, 'z', npix=300)
+projector = pa.RayProjector(snap, center, widths, 'z', npix=300, tol=2)
 
-    # tree_M = tree_projector.project_variable('0_Masses')
-    # tree_V = tree_projector.project_variable('0_Volume')
-    # tree_rho = tree_M / tree_V
-    tree_rho = tree_projector.project_variable('0_Density', additive=False)
+# tree_M = tree_projector.project_variable('0_Masses')
+# tree_V = tree_projector.project_variable('0_Volume')
+# tree_rho = tree_M / tree_V
+tree_rho = tree_projector.project_variable('0_Density', additive=False)
 
-    rho = projector.project_variable('0_Density', additive=False)
-    # V = projector.project_variable('0_Volume', additive=False)
-    # rho = M / V
+rho = projector.project_variable('0_Density', additive=False)
+# V = projector.project_variable('0_Volume', additive=False)
+# rho = M / V
 
-    rel_rho = (np.abs(tree_rho - rho) / tree_rho)
-    # rel_M = (np.abs(tree_M - M) / tree_M)
+rel_rho = (np.abs(tree_rho - rho) / tree_rho)
+# rel_M = (np.abs(tree_M - M) / tree_M)
 
-    # assert np.max(rel_rho.value) < 0.17, np.max(rel_rho.value)
+# assert np.max(rel_rho.value) < 0.17, np.max(rel_rho.value)
 
-    # Only check away from boundaries since we do not do these correctly
-    # with the SPH projector.
-    # M_err = np.max(rel_M[35:65, 100:200])
-    # assert M_err < 0.16, M_err
+# Only check away from boundaries since we do not do these correctly
+# with the SPH projector.
+# M_err = np.max(rel_M[35:65, 100:200])
+# assert M_err < 0.16, M_err
 
-    if show:
-        import matplotlib.pyplot as plt
+if show:
+    import matplotlib.pyplot as plt
 
-        plt.figure(1)
-        plt.clf()
-        fig, axes = plt.subplots(num=1, nrows=3, sharex=True)
+    plt.figure(1)
+    plt.clf()
+    fig, axes = plt.subplots(num=1, nrows=3, sharex=True)
 
-        # Define new imshow_wo_units that automatically plots the values
-        fig.suptitle('Density plots')
-        imshow_wo_units = pa.util.remove_astro_units(axes[0].imshow)
-        imshow_wo_units(rho, extent=projector.extent,
-                        vmin=rho.min(), vmax=rho.max())
-        axes[0].set_ylabel(projector.extent.label('y'))
-        axes[0].set_title('RayProjector')
+    # Define new imshow_wo_units that automatically plots the values
+    fig.suptitle('Density plots')
+    imshow_wo_units = pa.util.remove_astro_units(axes[0].imshow)
+    imshow_wo_units(rho, extent=projector.extent,
+                    vmin=rho.min(), vmax=rho.max())
+    axes[0].set_ylabel(projector.extent.label('y'))
+    axes[0].set_title('RayProjector')
 
-        imshow_wo_units = pa.util.remove_astro_units(axes[1].imshow)
-        imshow_wo_units(tree_rho.value, extent=tree_projector.extent.value,
-                        vmin=rho.min(), vmax=rho.max())
-        axes[1].set_ylabel(tree_projector.extent.label('y'))
-        axes[1].set_title('TreeProjector')
+    imshow_wo_units = pa.util.remove_astro_units(axes[1].imshow)
+    imshow_wo_units(tree_rho.value, extent=tree_projector.extent.value,
+                    vmin=tree_rho.min(), vmax=tree_rho.max())
+    axes[1].set_ylabel(tree_projector.extent.label('y'))
+    axes[1].set_title('TreeProjector')
 
-        axes[2].imshow(rel_rho.value, extent=tree_projector.extent.value)
-        axes[2].set_ylabel(tree_projector.extent.label('y'))
-        axes[2].set_xlabel(tree_projector.extent.label('x'))
-        axes[2].set_title('Rel difference')
+    axes[2].imshow(rel_rho.value, extent=tree_projector.extent.value)
+    axes[2].set_ylabel(tree_projector.extent.label('y'))
+    axes[2].set_xlabel(tree_projector.extent.label('x'))
+    axes[2].set_title('Rel difference')
 
-        plt.show()
+    plt.show()
 
 
-if __name__ == '__main__':
-    test_tree_projector_vs_ray_projector(True)
+# if __name__ == '__main__':
+#     test_tree_projector_vs_ray_projector(True)


### PR DESCRIPTION
There is now a CPU implementation of GpuRayProjector, which is called simply RayProjector.

- Binary tree on the CPU is now much faster, as the tree generation code has been ported from python to cython.
- RayProjector has been implemented. In addition to project_variable, it also supports a new project_variables (plural), which speeds things up (`examples/ray_projector_example.py`). A comparison with the TreeProjector is given in `examples/example_cpu_ray_projector_expensive.py`
- RayProjector also supports parttype != 0, i.e., point particles and not just Voronoi cells. GpuRayProjector has similarly been updated. @lenajlassi uses this feature for projecting tracer particles.
- The binary trees have been updated to better handle non-unique coordinates (which give rise to non-unique Morton codes). This has been a problem for simulations with single precision coordinate output and/or tracer particle output.
- Binary BVH tree now has a range search on the CPU (to find all points inside a sphere of a given radius). See `examples/binary_tree_example.py`